### PR TITLE
Update Remotely_Server_Install.sh

### DIFF
--- a/Utilities/Remotely_Server_Install.sh
+++ b/Utilities/Remotely_Server_Install.sh
@@ -139,6 +139,6 @@ systemctl restart remotely.service
 
 
 # Install Certbot and get SSL cert.
-apt-get -y install certbot python-certbot-nginx
+apt -y install certbot python3-certbot-nginx
 
 certbot --nginx


### PR DESCRIPTION
root@remotely:/home/admin# apt-get -y install certbot python-certbot-nginx
Reading package lists... Done
Building dependency tree
Reading state information... Done
Package python-certbot-nginx is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python3-certbot-nginx

E: Package 'python-certbot-nginx' has no installation candidate